### PR TITLE
Note to users about reviving dead cores

### DIFF
--- a/src/ui/reactors-corelist.jsx
+++ b/src/ui/reactors-corelist.jsx
@@ -237,6 +237,9 @@ export const CoreList = ({
           />
         </Form>
       </Card.Header>
+      <Card.Body>
+        <p> Caution: Setting ALL cores to 100 percent power activates cores that have been permanently shutdown. </p>
+      </Card.Body>
       <ListGroup variant="flush">
         <ListGroup.Item>
         <Row>


### PR DESCRIPTION
Add note to card cautioning users about turning on cores that have been permanently shutdown