### PR TITLE
fix x-axis value ranges, add Plotly filenames- reactors plots

### DIFF
--- a/src/ui/reactors-plots.jsx
+++ b/src/ui/reactors-plots.jsx
@@ -223,7 +223,7 @@ export const CoreDirectionSignalPlots = ({ cores }) => {
   };
   var config = {
     toImageButtonOptions: {
-      filename: 'Core-Directions-signal-vs-cos&theta;'
+      filename: 'Core-Directions-signal-vs-cos(theta)'
     }
   };
   return (

--- a/src/ui/reactors-plots.jsx
+++ b/src/ui/reactors-plots.jsx
@@ -201,7 +201,7 @@ export const CoreDirectionSignalPlots = ({ cores }) => {
       autorange: true
     },
     xaxis: {
-      range: [-1 , 1.05],
+      range: [-1.05 , 1.05],
       zeroline: false,
       title: { text: `cosθ` },
     },

--- a/src/ui/reactors-plots.jsx
+++ b/src/ui/reactors-plots.jsx
@@ -201,6 +201,7 @@ export const CoreDirectionSignalPlots = ({ cores }) => {
       autorange: true
     },
     xaxis: {
+      range: [-1 , 1],
       zeroline: false,
       title: { text: `cosθ` },
     },
@@ -231,9 +232,7 @@ export const CoreDirectionSignalPlots = ({ cores }) => {
           useResizeHandler={true}
           style={{ width: "100%" }}
           data={data}
-          layout={
-            xaxis: {range: [-1 , 1]}
-          }
+          layout={layout}
         />
       </Card.Body>
     </Card>

--- a/src/ui/reactors-plots.jsx
+++ b/src/ui/reactors-plots.jsx
@@ -74,6 +74,11 @@ export const FissionIsotopeSpectraPlots = () => {
       },
     ],
   };
+  var config = {
+    toImageButtonOptions: {
+      filename: 'Fission-Isotope-Spectra'
+    }
+  };
   return (
     <Card>
       <Card.Header>Fission Isotope Emission Spectra</Card.Header>
@@ -95,6 +100,7 @@ export const FissionIsotopeSpectraPlots = () => {
           style={{ width: "100%" }}
           data={data}
           layout={layout}
+          config={config}
         />
       </Card.Body>
     </Card>

--- a/src/ui/reactors-plots.jsx
+++ b/src/ui/reactors-plots.jsx
@@ -223,7 +223,7 @@ export const CoreDirectionSignalPlots = ({ cores }) => {
   };
   var config = {
     toImageButtonOptions: {
-      filename: 'Core-Directions-wrt-${first.name}'
+      filename: 'Core-Directions-signal-vs-cos&theta;'
     }
   };
   return (

--- a/src/ui/reactors-plots.jsx
+++ b/src/ui/reactors-plots.jsx
@@ -231,7 +231,9 @@ export const CoreDirectionSignalPlots = ({ cores }) => {
           useResizeHandler={true}
           style={{ width: "100%" }}
           data={data}
-          layout={layout}
+          layout={
+            xaxis: {range: [-1 , 1]}
+          }
         />
       </Card.Body>
     </Card>

--- a/src/ui/reactors-plots.jsx
+++ b/src/ui/reactors-plots.jsx
@@ -201,7 +201,7 @@ export const CoreDirectionSignalPlots = ({ cores }) => {
       autorange: true
     },
     xaxis: {
-      range: [-1 , 1],
+      range: [-1 , 1.05],
       zeroline: false,
       title: { text: `cosθ` },
     },

--- a/src/ui/reactors-plots.jsx
+++ b/src/ui/reactors-plots.jsx
@@ -221,6 +221,11 @@ export const CoreDirectionSignalPlots = ({ cores }) => {
       },
     ],
   };
+  var config = {
+    toImageButtonOptions: {
+      filename: 'Core-Directions'
+    }
+  };
   return (
     <Card>
       <Card.Header>Core Directions Plot</Card.Header>

--- a/src/ui/reactors-plots.jsx
+++ b/src/ui/reactors-plots.jsx
@@ -223,7 +223,7 @@ export const CoreDirectionSignalPlots = ({ cores }) => {
   };
   var config = {
     toImageButtonOptions: {
-      filename: 'Core-Directions'
+      filename: 'Core-Directions-wrt-${first.name}'
     }
   };
   return (

--- a/src/ui/reactors-plots.jsx
+++ b/src/ui/reactors-plots.jsx
@@ -238,6 +238,7 @@ export const CoreDirectionSignalPlots = ({ cores }) => {
           style={{ width: "100%" }}
           data={data}
           layout={layout}
+          config={config}
         />
       </Card.Body>
     </Card>


### PR DESCRIPTION
The Core Direction Plot with 0 (1) core on displays cos(theta) values from 0 to 6 (2) but cos(theta)>1 is not possible. The cos(theta) range on the plot needs to be fixed to only display values [-1,1].

Above taken from comment on Issue #98

If this works, then will do the same for main spectrum plot