### PR TITLE
try fix x-axis values on spectrum plot to be 0-10

### DIFF
--- a/src/ui/plot.jsx
+++ b/src/ui/plot.jsx
@@ -141,6 +141,7 @@ export function NuSpectrumPlot({ cores, spectrum, detector}) {
     },
     autosize: true,
     xaxis: {
+      range: [0, 10],
       title: { text: `Antineutrino Energy E (MeV)` },
     },
     yaxis: {


### PR DESCRIPTION
turning off all cores and geo-neutrinos makes the x-axis values show as 0 to 6 MeV. This should fix the values to always be 0 to 10 MeV.