### PR TITLE
CoreDirectionsPlot- add detector to title

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -224,6 +224,7 @@ function App(props) {
                 <Visible>
                   <CoreDirectionSignalPlots
                     cores={cores}
+                    detector={detector}
                     reactorLF={reactorLF}
                   />
                 </Visible>

--- a/src/ui/reactors-plots.jsx
+++ b/src/ui/reactors-plots.jsx
@@ -107,7 +107,7 @@ export const FissionIsotopeSpectraPlots = () => {
   );
 };
 
-export const CoreDirectionSignalPlots = ({ cores, reactorLF }) => {
+export const CoreDirectionSignalPlots = ({ cores, detector, reactorLF }) => {
   const sortedCores = Object.values(cores)
     .filter((a) => a.detectorNIU > 0)
     .sort((a, b) => b.detectorNIU - a.detectorNIU);
@@ -200,7 +200,12 @@ export const CoreDirectionSignalPlots = ({ cores, reactorLF }) => {
   ];
   var layout = {
     hovermode: "closest",
-    title: `Core Directions w.r.t. ${first.name}<br /><sub>(${reactorLF.start.toISOString().slice(0, 7)} through ${reactorLF.end.toISOString().slice(0, 7)} avg Load Factor)</sub>`,
+    title: `Core Directions w.r.t. ${
+      ["custom", "follow"].includes(detector.current)
+        ? "Custom Location"
+        : detector.current
+    }
+    to ${first.name}<br /><sub>(${reactorLF.start.toISOString().slice(0, 7)} through ${reactorLF.end.toISOString().slice(0, 7)} avg Load Factor)</sub>`,
     yaxis: {
       title: { text: `signal (NIU)` },
       type: 'log',

--- a/src/ui/reactors-plots.jsx
+++ b/src/ui/reactors-plots.jsx
@@ -204,8 +204,7 @@ export const CoreDirectionSignalPlots = ({ cores, detector, reactorLF }) => {
       ["custom", "follow"].includes(detector.current)
         ? "Custom Location"
         : detector.current
-    }
-    to ${first.name}<br /><sub>(${reactorLF.start.toISOString().slice(0, 7)} through ${reactorLF.end.toISOString().slice(0, 7)} avg Load Factor)</sub>`,
+    } to ${first.name}<br /><sub>(${reactorLF.start.toISOString().slice(0, 7)} through ${reactorLF.end.toISOString().slice(0, 7)} avg Load Factor)</sub>`,
     yaxis: {
       title: { text: `signal (NIU)` },
       type: 'log',


### PR DESCRIPTION
Currently, the reference direction in the title is ambiguous b/c it only mentions the reactor core but not the detector. A direction is defined by two points not one.

this will cause site to crash when selecting Reactors tab until I add "detector" to the import list in App.js

Hmm.. How to include revised App.js without creating a PR?