### PR TITLE
Unify eV bins and remove assumptions about bin widths

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -287,7 +287,7 @@ function App(props) {
                 <h2> REFERENCE </h2>
                 <p> The model presented by this website is fully documented in this paper{" "}
                 <a href="https://arxiv.org/pdf/1510.05633.pdf">arXiv:1510.05633.v3</a>. 
-                Please referee this paper when using the results of this model in your research papers and presentations.</p>
+                Please reference this paper when using the results of this model in your research papers and presentations.</p>
                 <Visible>
                   <OutputDownload
                     spectrum={spectrum}
@@ -298,7 +298,7 @@ function App(props) {
                 </Visible>
                 <CalculatorPanel cores={cores} spectrum={spectrum} />
                 <h2> ACKNOWLEDGMENT </h2>
-                <p> Development of the model and this web application was supported in part by Lawrence Livermore National 
+                <p> Development of the model and this web application is supported in part by Lawrence Livermore National 
                 Security, LLC. </p>
               </Tab>
             </Tabs>

--- a/src/App.js
+++ b/src/App.js
@@ -36,6 +36,7 @@ import {
   FissionFractionPane,
   FissionIsotopeSpectraPlots,
   //Output Tab
+  KESpectrumPlot,
   OutputDownload,
   CalculatorPanel,
   //solar tab
@@ -287,7 +288,13 @@ function App(props) {
                 <h2> REFERENCE </h2>
                 <p> The model presented by this website is fully documented in this paper{" "}
                 <a href="https://arxiv.org/pdf/1510.05633.pdf">arXiv:1510.05633.v3</a>. 
-                Please reference this paper when using the results of this model in your research papers and presentations.</p>
+                Please referee this paper when using the results of this model in your research papers and presentations.</p>
+                <KESpectrumPlot
+              detector={detector}
+              cores={cores}
+              spectrum={spectrum}
+              reactorLF={reactorLF}
+            />
                 <Visible>
                   <OutputDownload
                     spectrum={spectrum}

--- a/src/App.js
+++ b/src/App.js
@@ -36,7 +36,6 @@ import {
   FissionFractionPane,
   FissionIsotopeSpectraPlots,
   //Output Tab
-  KESpectrumPlot,
   OutputDownload,
   CalculatorPanel,
   //solar tab
@@ -289,12 +288,6 @@ function App(props) {
                 <p> The model presented by this website is fully documented in this paper{" "}
                 <a href="https://arxiv.org/pdf/1510.05633.pdf">arXiv:1510.05633.v3</a>. 
                 Please referee this paper when using the results of this model in your research papers and presentations.</p>
-                <KESpectrumPlot
-              detector={detector}
-              cores={cores}
-              spectrum={spectrum}
-              reactorLF={reactorLF}
-            />
                 <Visible>
                   <OutputDownload
                     spectrum={spectrum}

--- a/src/antineutrino-spectrum/index.ts
+++ b/src/antineutrino-spectrum/index.ts
@@ -29,6 +29,7 @@ function resample(
 ): Float32Array {
   const output = new Float32Array(size).fill(0);
   const binWidth = (stop - start) / size;
+  //TODO assumption about bins
   const sliceSize = Math.floor(binWidth * 1000);
 
   return output.map((v, i) => {
@@ -73,6 +74,7 @@ export const antineutrinoSpectrum238U = resample(
 function rateToFluxCalc(spectrum: number[], crossSection: CrossSectionFunc): number {
   const targets = 1e32;
   const rate_to_flux_n = spectrum.reduce((p, v) => p + v, 0);
+  //TODO assumption about bins
   const rate_to_flux_d = spectrum
     .map((v, i) => {
       return v * crossSection(0.0005 + i / 1000);

--- a/src/antineutrino-spectrum/index.ts
+++ b/src/antineutrino-spectrum/index.ts
@@ -31,13 +31,13 @@ function resample(
 ): Float32Array {
   const output = new Float32Array(size).fill(0);
   const binWidth = (stop - start) / size;
-  //TODO assumption about bins
-  const sliceSize = Math.floor(binWidth * size);
+  const inputBinWidth = 1/1000
+  const sliceSize = Math.floor(binWidth/inputBinWidth);
 
   return output.map((v, i) => {
     return antineutrinoSpectrum
       .slice(i * sliceSize, i * sliceSize + sliceSize)
-      .reduce((p, c) => p + c * 100, 0);
+      .reduce((p, c) => p + c * binCount/10, 0);
   });
 }
 

--- a/src/antineutrino-spectrum/index.ts
+++ b/src/antineutrino-spectrum/index.ts
@@ -7,6 +7,8 @@ import { SECONDS_PER_YEAR } from "../physics/constants";
 
 import { CrossSectionFunc, XSNames, CrossSection, crossSection } from "../physics/neutrino-cross-section";
 
+import {binCount} from "../physics/bins"
+
 //interface RateToFlux {
 //  IBDSV2003: number;
 //  IBDVB1999: number;
@@ -30,7 +32,7 @@ function resample(
   const output = new Float32Array(size).fill(0);
   const binWidth = (stop - start) / size;
   //TODO assumption about bins
-  const sliceSize = Math.floor(binWidth * 1000);
+  const sliceSize = Math.floor(binWidth * size);
 
   return output.map((v, i) => {
     return antineutrinoSpectrum
@@ -50,25 +52,25 @@ export const antineutrinoSpectrum40K = resample(
   antineutrinoSpectrum40KData,
   0,
   10,
-  1000
+  binCount
 );
 export const antineutrinoSpectrum232Th = resample(
   antineutrinoSpectrum232ThData,
   0,
   10,
-  1000
+  binCount
 );
 export const antineutrinoSpectrum235U = resample(
   antineutrinoSpectrum235UData,
   0,
   10,
-  1000
+  binCount
 );
 export const antineutrinoSpectrum238U = resample(
   antineutrinoSpectrum238UData,
   0,
   10,
-  1000
+  binCount
 );
 
 function rateToFluxCalc(spectrum: number[], crossSection: CrossSectionFunc): number {

--- a/src/mantle/index.ts
+++ b/src/mantle/index.ts
@@ -15,13 +15,14 @@ import {
 } from "../physics/constants";
 import { ISOTOPIC_NEUTRINO_LUMINOSITY } from "../physics/derived";
 import { zip } from "lodash";
+import bins from "../physics/bins";
 
 const MICROSECOND_PER_SECOND = 1e6;
 const TARGETS = 1e32;
 
 const TargetYears = TARGETS * SECONDS_PER_YEAR;
 
-const EvBinFronIndex = (i: number) => 0.005 + i / 100;
+const EvBinFronIndex = (i: number) => bins[i];
 
 const extractESEandMuTau = (
   spec: number,

--- a/src/physics/bins.ts
+++ b/src/physics/bins.ts
@@ -14,7 +14,6 @@ const IBD_bin_remainder = IBD_THRESHOLD/binWidth - Math.floor(IBD_THRESHOLD/binW
 export const IBD_threshold_bin = IBD_bin_remainder < 0.5? Math.floor(IBD_THRESHOLD/binWidth) : Math.floor(IBD_THRESHOLD/binWidth) + 1
 
 const calcBins = (binStart:number, binEnd:number, binCount:number, binAlign:number):Float64Array => {
-//  const offset = binWidth * binAlign;
 // we use midpoint numerical integration
   const offset = binWidth * 0.5
   return new Float64Array(binCount).map((_, i) => binStart + offset + binWidth * i)

--- a/src/physics/bins.ts
+++ b/src/physics/bins.ts
@@ -11,10 +11,17 @@ export const binWidth = (binEnd - binStart) / binCount;
 const IBD_bin_remainder = IBD_THRESHOLD/binWidth - Math.floor(IBD_THRESHOLD/binWidth)
 // we always want the number to be between 0 and 1
 export const binAlign = IBD_bin_remainder < 0.5? IBD_bin_remainder + 0.5 : IBD_bin_remainder - 0.5
+export const IBD_threshold_bin = IBD_bin_remainder < 0.5? Math.floor(IBD_THRESHOLD/binWidth) : Math.floor(IBD_THRESHOLD/binWidth) + 1
 
 const calcBins = (binStart:number, binEnd:number, binCount:number, binAlign:number):Float64Array => {
   const offset = binWidth * binAlign;
   return new Float64Array(binCount).map((_, i) => binStart + offset + binWidth * i)
+}
+
+export const shiftByIBD = (arr:number[]|Float64Array|Float32Array):Float64Array => {
+  const output = (new Float64Array(binCount)).fill(0)
+  output.set(arr.slice(IBD_threshold_bin))
+  return output
 }
 
 export default calcBins(binStart, binEnd, binCount, binAlign)

--- a/src/physics/bins.ts
+++ b/src/physics/bins.ts
@@ -1,11 +1,11 @@
 export const binStart = 0 // MeV
 export const binEnd = 10 // MeV
 export const binCount = 1000
-export const binAlign = 0.5 // number between 0 and 1, 0 is left edge, 1 is right edge
+export const binAlign = 0.107 // number between 0 and 1, 0 is left edge, 1 is right edge
 
+export const binWidth = (binEnd - binStart) / binCount;
 
 const calcBins = (binStart:number, binEnd:number, binCount:number, binAlign:number):Float64Array => {
-  const binWidth = (binEnd - binStart) / binCount;
   const offset = binWidth * binAlign;
   return new Float64Array(binCount).map((_, i) => binStart + offset + binWidth * i)
 }

--- a/src/physics/bins.ts
+++ b/src/physics/bins.ts
@@ -14,7 +14,9 @@ const IBD_bin_remainder = IBD_THRESHOLD/binWidth - Math.floor(IBD_THRESHOLD/binW
 export const IBD_threshold_bin = IBD_bin_remainder < 0.5? Math.floor(IBD_THRESHOLD/binWidth) : Math.floor(IBD_THRESHOLD/binWidth) + 1
 
 const calcBins = (binStart:number, binEnd:number, binCount:number, binAlign:number):Float64Array => {
-  const offset = binWidth * binAlign;
+//  const offset = binWidth * binAlign;
+// we use midpoint numerical integration
+  const offset = binwidth * 0.5
   return new Float64Array(binCount).map((_, i) => binStart + offset + binWidth * i)
 }
 

--- a/src/physics/bins.ts
+++ b/src/physics/bins.ts
@@ -1,9 +1,16 @@
+import {IBD_THRESHOLD} from "./derived"
+
 export const binStart = 0 // MeV
 export const binEnd = 10 // MeV
 export const binCount = 1000
-export const binAlign = 0.107 // number between 0 and 1, 0 is left edge, 1 is right edge
+//export const binAlign = 0.107 // number between 0 and 1, 0 is left edge, 1 is right edge
 
 export const binWidth = (binEnd - binStart) / binCount;
+
+// This figures out which bin the IBD threshold is in and ensure that the bin center is always 0.5 binwidths away
+const IBD_bin_remainder = IBD_THRESHOLD/binWidth - Math.floor(IBD_THRESHOLD/binWidth)
+// we always want the number to be between 0 and 1
+export const binAlign = IBD_bin_remainder < 0.5? IBD_bin_remainder + 0.5 : IBD_bin_remainder - 0.5
 
 const calcBins = (binStart:number, binEnd:number, binCount:number, binAlign:number):Float64Array => {
   const offset = binWidth * binAlign;

--- a/src/physics/bins.ts
+++ b/src/physics/bins.ts
@@ -2,7 +2,7 @@ import {IBD_THRESHOLD} from "./derived"
 
 export const binStart = 0 // MeV
 export const binEnd = 10 // MeV
-export const binCount = 2000
+export const binCount = 1000
 export const binAlign = 1e-40 // number in the range (0, 1] 0 is left edge (not inclusive), 1 is right edge
 
 export const binWidth = (binEnd - binStart) / binCount;

--- a/src/physics/bins.ts
+++ b/src/physics/bins.ts
@@ -16,7 +16,7 @@ export const IBD_threshold_bin = IBD_bin_remainder < 0.5? Math.floor(IBD_THRESHO
 const calcBins = (binStart:number, binEnd:number, binCount:number, binAlign:number):Float64Array => {
 //  const offset = binWidth * binAlign;
 // we use midpoint numerical integration
-  const offset = binwidth * 0.5
+  const offset = binWidth * 0.5
   return new Float64Array(binCount).map((_, i) => binStart + offset + binWidth * i)
 }
 

--- a/src/physics/bins.ts
+++ b/src/physics/bins.ts
@@ -3,7 +3,7 @@ import {IBD_THRESHOLD} from "./derived"
 export const binStart = 0 // MeV
 export const binEnd = 10 // MeV
 export const binCount = 1000
-export const binAlign = 1e-40 // number in the range (0, 1] 0 is left edge (not inclusive), 1 is right edge
+export const binAlign = 0.5 // number in the range (0, 1] 0 is left edge (not inclusive), 1 is right edge
 
 export const binWidth = (binEnd - binStart) / binCount;
 
@@ -14,8 +14,7 @@ const IBD_bin_remainder = IBD_THRESHOLD/binWidth - Math.floor(IBD_THRESHOLD/binW
 export const IBD_threshold_bin = IBD_bin_remainder < 0.5? Math.floor(IBD_THRESHOLD/binWidth) : Math.floor(IBD_THRESHOLD/binWidth) + 1
 
 const calcBins = (binStart:number, binEnd:number, binCount:number, binAlign:number):Float64Array => {
-// we use midpoint numerical integration
-  const offset = binWidth * 0.5
+  const offset = binWidth * binAlign
   return new Float64Array(binCount).map((_, i) => binStart + offset + binWidth * i)
 }
 

--- a/src/physics/bins.ts
+++ b/src/physics/bins.ts
@@ -1,0 +1,13 @@
+export const binStart = 0 // MeV
+export const binEnd = 10 // MeV
+export const binCount = 1000
+export const binAlign = 0.5 // number between 0 and 1, 0 is left edge, 1 is right edge
+
+
+const calcBins = (binStart:number, binEnd:number, binCount:number, binAlign:number):Float64Array => {
+  const binWidth = (binEnd - binStart) / binCount;
+  const offset = binWidth * binAlign;
+  return new Float64Array(binCount).map((_, i) => binStart + offset + binWidth * i)
+}
+
+export default calcBins(binStart, binEnd, binCount, binAlign)

--- a/src/physics/bins.ts
+++ b/src/physics/bins.ts
@@ -2,15 +2,15 @@ import {IBD_THRESHOLD} from "./derived"
 
 export const binStart = 0 // MeV
 export const binEnd = 10 // MeV
-export const binCount = 1000
-//export const binAlign = 0.107 // number between 0 and 1, 0 is left edge, 1 is right edge
+export const binCount = 2000
+export const binAlign = 1e-40 // number in the range (0, 1] 0 is left edge (not inclusive), 1 is right edge
 
 export const binWidth = (binEnd - binStart) / binCount;
 
 // This figures out which bin the IBD threshold is in and ensure that the bin center is always 0.5 binwidths away
 const IBD_bin_remainder = IBD_THRESHOLD/binWidth - Math.floor(IBD_THRESHOLD/binWidth)
 // we always want the number to be between 0 and 1
-export const binAlign = IBD_bin_remainder < 0.5? IBD_bin_remainder + 0.5 : IBD_bin_remainder - 0.5
+//export const binAlign = IBD_bin_remainder < 0.5? IBD_bin_remainder + 0.5 : IBD_bin_remainder - 0.5
 export const IBD_threshold_bin = IBD_bin_remainder < 0.5? Math.floor(IBD_THRESHOLD/binWidth) : Math.floor(IBD_THRESHOLD/binWidth) + 1
 
 const calcBins = (binStart:number, binEnd:number, binCount:number, binAlign:number):Float64Array => {

--- a/src/physics/neutrino-cross-section.ts
+++ b/src/physics/neutrino-cross-section.ts
@@ -136,13 +136,13 @@ export function differentialCrossSectionElasticScatteringAngular(Ev: number, cos
   return diffXs * diffTe;
 }
 
-function crossSectionElasticScattering(Ev: number, neutrinoType: NeutrinoType, T_min:number = 0): number {
+export function crossSectionElasticScattering(Ev: number, neutrinoType: NeutrinoType, T_min:number = 0, Tmax?:number): number {
   const cL = ES_COEFFICIENTS_LEFT[neutrinoType]
   const cR = ES_COEFFICIENTS_RIGHT[neutrinoType]
 
   // The following impliments equation 13... it's big so there will be
   // 4 terms to make the equation the following: term1(term2 + term3 - term4)
-  const T_max = TEMax(Ev) 
+  const T_max = Tmax !== undefined && Tmax < TEMax(Ev)? Tmax: TEMax(Ev)
   if (T_max < T_min){
     return 0;
   }

--- a/src/physics/neutrino-cross-section.ts
+++ b/src/physics/neutrino-cross-section.ts
@@ -1,4 +1,5 @@
-import { ELECTRON_REST_MASS, NEUTRON_REST_MASS, PROTON_REST_MASS, HBAR_C, FERMI_COUPLING_CONSTANT, WEAK_MIXING_ANGLE } from './constants'
+import { ELECTRON_REST_MASS, HBAR_C, FERMI_COUPLING_CONSTANT, WEAK_MIXING_ANGLE } from './constants'
+import {IBD_THRESHOLD} from "./derived"
 import { memoize } from 'lodash';
 
 export interface CrossSectionFunc {
@@ -62,11 +63,9 @@ export const crossSectionSV2003: CrossSectionFunc = memoize((Ev) => {
 
 //  const Delta = NEUTRON_REST_MASS - PROTON_REST_MASS;
 
-  const E_thresh = (((ELECTRON_REST_MASS + NEUTRON_REST_MASS) ** 2) - PROTON_REST_MASS ** 2) / (2 * PROTON_REST_MASS) 
-  
 //  const Ee = Math.max(ELECTRON_REST_MASS, Ev - Delta)
   
-  const Ee = Math.max(ELECTRON_REST_MASS, Ev - E_thresh + ELECTRON_REST_MASS)
+  const Ee = Math.max(ELECTRON_REST_MASS, Ev - IBD_THRESHOLD + ELECTRON_REST_MASS)
   
   const Pe = Math.sqrt(Ee ** 2 - ELECTRON_REST_MASS ** 2) // electron momentum
 
@@ -84,8 +83,7 @@ export const crossSectionSV2003: CrossSectionFunc = memoize((Ev) => {
  * Corrected the expression for the electron energy Ee
 */
 export const crossSectionVB1999: CrossSectionFunc = memoize((Ev) => {
-  const E_thresh = (((ELECTRON_REST_MASS + NEUTRON_REST_MASS) ** 2) - PROTON_REST_MASS ** 2) / (2 * PROTON_REST_MASS)
-  const Ee = Math.max(ELECTRON_REST_MASS, Ev - E_thresh + ELECTRON_REST_MASS)
+  const Ee = Math.max(ELECTRON_REST_MASS, Ev - IBD_THRESHOLD + ELECTRON_REST_MASS)
   //  const Ee = Math.max(ELECTRON_REST_MASS, Ev - (NEUTRON_REST_MASS - PROTON_REST_MASS));
 
   return 9.52e-44 * Math.sqrt((Ee * Ee) - (ELECTRON_REST_MASS * ELECTRON_REST_MASS)) * Ee;

--- a/src/physics/neutrino-oscillation.ts
+++ b/src/physics/neutrino-oscillation.ts
@@ -1,4 +1,5 @@
 import { memoize } from 'lodash';
+import bins from "./bins"
 
 export enum MassOrdering {
     Inverted = "Inverted",
@@ -74,8 +75,6 @@ export let oscillation: Oscillation = {
   // Config things
   massOrdering: MassOrdering.Normal
 }
-
-export const bins = (new Float64Array(1000)).map((v, i) => 0.005 + i/100)
 
 const defaultOscillationParams: VariableOscillationParams = {
   s2t12: 0.310,

--- a/src/reactor-cores/index.ts
+++ b/src/reactor-cores/index.ts
@@ -17,13 +17,12 @@ import {
 import { zip, sum } from "lodash";
 import { project } from "ecef-projector";
 import { Oscillation } from "../physics/neutrino-oscillation";
+import bins from "../physics/bins";
 
 export { cores, times, loads };
 
 const SECONDS_PER_YEAR = 365.25 * 24 * 60 * 60;
 
-// TODO Centralize this function
-const bins = (new Float64Array(1000)).map((v, i) => 0.005 + i/100)
 
 const cos_deg = (deg: number) => Math.cos(deg * (Math.PI / 180));
 
@@ -378,6 +377,7 @@ export function ReactorCore({
     powerFractions: powerFractions,
     loadFactor: loadFactor,
     detectorDistance: 0,
+    //TODO assumption about bins
     detectorSignal: new Float64Array(1000).fill(0),
     detectorAnySignal: false,
     detectorNIU: 0,

--- a/src/reactor-cores/index.ts
+++ b/src/reactor-cores/index.ts
@@ -17,7 +17,7 @@ import {
 import { zip, sum } from "lodash";
 import { project } from "ecef-projector";
 import { Oscillation } from "../physics/neutrino-oscillation";
-import bins from "../physics/bins";
+import bins, {binWidth, binCount} from "../physics/bins";
 
 export { cores, times, loads };
 
@@ -339,7 +339,7 @@ export function ReactorCore({
       );
     });
 
-    const detectorNIU = sum(signal) * 0.01;
+    const detectorNIU = sum(signal) * binWidth;
     const detectorAnySignal = detectorNIU > 0;
 
     return {
@@ -378,7 +378,7 @@ export function ReactorCore({
     loadFactor: loadFactor,
     detectorDistance: 0,
     //TODO assumption about bins
-    detectorSignal: new Float64Array(1000).fill(0),
+    detectorSignal: new Float64Array(binCount).fill(0),
     detectorAnySignal: false,
     detectorNIU: 0,
     setSignal: setSignal,

--- a/src/ui/detector-stats.jsx
+++ b/src/ui/detector-stats.jsx
@@ -12,6 +12,7 @@ import {
 import { ISOTOPIC_NEUTRINO_LUMINOSITY } from "../physics/derived";
 import { ISOTOPIC_NATURAL_ABUNDANCE } from "../physics/constants";
 import {PhysicsContext} from "../state"
+import { binWidth } from "../physics/bins";
 
 import { Num } from '.'
 
@@ -71,17 +72,17 @@ export function StatsPanel({ cores, spectrum, reactorLF}) {
   const customDisplay = customTotalSignal > 0 ? "block" : "none";
 
   // geo things
-  const geo_crustU238NIU = sum(spectrum.geo_crustU238) * 0.01;
-  const geo_mantleU238NIU = sum(spectrum.geo_mantleU238) * 0.01;
+  const geo_crustU238NIU = sum(spectrum.geo_crustU238) * binWidth;
+  const geo_mantleU238NIU = sum(spectrum.geo_mantleU238) * binWidth;
   const geoU238NIU = geo_crustU238NIU + geo_mantleU238NIU;
-  const geo_crustTh232NIU = sum(spectrum.geo_crustTh232) * 0.01;
-  const geo_mantleTh232NIU = sum(spectrum.geo_mantleTh232) * 0.01;
+  const geo_crustTh232NIU = sum(spectrum.geo_crustTh232) * binWidth;
+  const geo_mantleTh232NIU = sum(spectrum.geo_mantleTh232) * binWidth;
   const geoTh232NIU = geo_crustTh232NIU + geo_mantleTh232NIU;
-  const geo_crustU235NIU = sum(spectrum.geo_crustU235) * 0.01;
-  const geo_mantleU235NIU = sum(spectrum.geo_mantleU235) * 0.01;
+  const geo_crustU235NIU = sum(spectrum.geo_crustU235) * binWidth;
+  const geo_mantleU235NIU = sum(spectrum.geo_mantleU235) * binWidth;
   const geoU235NIU = geo_crustU235NIU + geo_mantleU235NIU;
-  const geo_crustK40betaNIU = sum(spectrum.geo_crustK40_beta) * 0.01;
-  const geo_mantleK40betaNIU = sum(spectrum.geo_mantleK40_beta) * 0.01;
+  const geo_crustK40betaNIU = sum(spectrum.geo_crustK40_beta) * binWidth;
+  const geo_mantleK40betaNIU = sum(spectrum.geo_mantleK40_beta) * binWidth;
   const geoK40betaNIU = geo_crustK40betaNIU + geo_mantleK40betaNIU
 
   const geoThU = geoThURatio(geoTh232NIU, geoU238NIU, crossSection.crossSection);

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useRef } from "react";
 
 export { NuMap } from './map';
-export { NuSpectrumPlot, CoreDirectionPlot } from './plot';
+export { NuSpectrumPlot, CoreDirectionPlot, KESpectrumPlot} from './plot';
 export { StatsPanel } from './detector-stats';
 export { DetectorPhysicsPane } from './detector-physics';
 export { DetectorLocationPane } from './detector-location';

--- a/src/ui/output-calculator.jsx
+++ b/src/ui/output-calculator.jsx
@@ -6,7 +6,7 @@ import { PhysicsContext } from "../state";
 import { XSNames } from "../physics/neutrino-cross-section";
 import { IBD_THRESHOLD } from "../physics/derived";
 import { Num, Visible } from ".";
-import { bins } from "../physics/neutrino-oscillation";
+import bins from "../physics/bins";
 import Plot from "react-plotly.js"
 
 const getCoreSums = (cores, min_i, max_i, low_i) => {

--- a/src/ui/output-calculator.jsx
+++ b/src/ui/output-calculator.jsx
@@ -28,12 +28,12 @@ const detectorEfficiency = (
   rampUp,
   turnOn,
   spectrum,
-  perfect = false
+  isIBD = false
 ) => {
-  if (perfect) {
-    return spectrum;
+  let shifted = spectrum;
+  if (isIBD) {
+    shifted = shiftByIBD(spectrum)
   }
-  const shifted = shiftByIBD(spectrum)
   return bins.map(
     (eV, i) =>
     effFunc(eV, Emax, rampUp, turnOn) * shifted[i]
@@ -120,12 +120,12 @@ export const CalculatorPanel = ({ cores, spectrum }) => {
   if (isIBD && ["geo_k", "geo_u5"].includes(signal)) {
     setSignal("closest");
   }
-  if (isIBD && eMin < parseFloat(IBD_THRESHOLD.toFixed(1))) {
-    setEMin(parseFloat(IBD_THRESHOLD.toFixed(3)));
-  }
-  if (!isIBD && eMin === parseFloat(IBD_THRESHOLD.toFixed(3))) {
-    setEMin(0);
-  }
+  //if (isIBD && eMin < parseFloat(IBD_THRESHOLD.toFixed(1))) {
+  //  setEMin(parseFloat(IBD_THRESHOLD.toFixed(3)));
+  //}
+  //if (!isIBD && eMin === parseFloat(IBD_THRESHOLD.toFixed(3))) {
+  //  setEMin(0);
+  //}
   
   const UIsetSelect = (event) => {
     var key = event.target.id;
@@ -276,7 +276,7 @@ export const CalculatorPanel = ({ cores, spectrum }) => {
         rampUp,
         enerStart,
         core.detectorSignal,
-        !isIBD
+        isIBD
       ),
     };
   });
@@ -310,28 +310,28 @@ export const CalculatorPanel = ({ cores, spectrum }) => {
 
   const geoU238NIU =
     sum(
-      detectorEfficiency(effMax, rampUp, enerStart, spectrum.geoU238, !isIBD).slice(
+      detectorEfficiency(effMax, rampUp, enerStart, spectrum.geoU238, isIBD).slice(
         min_i,
         max_i
       )
     ) * 0.01;
   const geoU235NIU =
     sum(
-      detectorEfficiency(effMax, rampUp, enerStart, spectrum.geoU235, !isIBD).slice(
+      detectorEfficiency(effMax, rampUp, enerStart, spectrum.geoU235, isIBD).slice(
         min_i,
         max_i
       )
     ) * 0.01;
   const geoTh232NIU =
     sum(
-      detectorEfficiency(effMax, rampUp, enerStart, spectrum.geoTh232, !isIBD).slice(
+      detectorEfficiency(effMax, rampUp, enerStart, spectrum.geoTh232, isIBD).slice(
         min_i,
         max_i
       )
     ) * 0.01;
   const geoK40betaNIU =
     sum(
-      detectorEfficiency(effMax, rampUp, enerStart, spectrum.geoK40_beta, !isIBD).slice(
+      detectorEfficiency(effMax, rampUp, enerStart, spectrum.geoK40_beta, isIBD).slice(
         min_i,
         max_i
       )

--- a/src/ui/output-calculator.jsx
+++ b/src/ui/output-calculator.jsx
@@ -87,7 +87,7 @@ export const CalculatorPanel = ({ cores, spectrum }) => {
       range: [0, 1.05]
     },
     xaxis: {
-      title: { text: `Kinetic Energy (MeV)` },
+      title: { text: `Kinetic Energy T (MeV)` },
       range: [0, 10]
     },
     autosize: true,
@@ -485,7 +485,8 @@ export const CalculatorPanel = ({ cores, spectrum }) => {
       <Card.Body>
         <Provider>
           <div>
-            <small>Detected events = efficiency fn (below) x interaction spectrum- {crossSection.crossSection}</small>
+            <small>Detected events = efficiency function x kinetic energy rate spectrum</small>
+//            <small>Detected events = efficiency fn (below) x interaction spectrum- {crossSection.crossSection}</small>
             <Table>
               <tbody>
               <tr>

--- a/src/ui/output-calculator.jsx
+++ b/src/ui/output-calculator.jsx
@@ -59,9 +59,9 @@ export const CalculatorPanel = ({ cores, spectrum }) => {
   const [deltaReactorsLowE, setDeltaReactorsLowE] = useState(0.3);
   // detection efficiency function parameters
   const [effMax, setEffMax] = useState(1.0);
-  const [enerStart, setEnerStart] = useState(
-    parseFloat(IBD_THRESHOLD.toFixed(1))
-  );
+  const [enerStart, setEnerStart] = useState(0.0);
+//    parseFloat(IBD_THRESHOLD.toFixed(1))
+//  );
   const [rampUp, setRampUp] = useState(1000);
 
   const { crossSection } = useContext(PhysicsContext);
@@ -81,13 +81,13 @@ export const CalculatorPanel = ({ cores, spectrum }) => {
   ]
   
   var layout = {
-    title: "IBD Detector Efficiency",
+    title: "Detector Efficiency",
     yaxis: {
       title: { text: `Detector Efficiency` },
       range: [0, 1.05]
     },
     xaxis: {
-      title: { text: `Neutrino Energy (MeV)` },
+      title: { text: `Kinetic Energy (MeV)` },
       range: [0, 10]
     },
     autosize: true,
@@ -152,14 +152,14 @@ export const CalculatorPanel = ({ cores, spectrum }) => {
 
   const UIsetEMin = (event) => {
     const value = event.target.value;
-    let stateEmin = parseFloat(IBD_THRESHOLD.toFixed(1)) * isIBD;
+//    let stateEmin = parseFloat(IBD_THRESHOLD.toFixed(1)) * isIBD;
     let e_min = parseFloat(value);
     if (isNaN(e_min)) {
       setEMin(value);
     } else {
-      if (e_min < stateEmin) {
-         e_min = stateEmin;
-       }
+//      if (e_min < stateEmin) {
+//         e_min = stateEmin;
+//       }
       if (e_min > 10) {
         e_min = 10;
       }      
@@ -207,14 +207,14 @@ export const CalculatorPanel = ({ cores, spectrum }) => {
 
   const UIsetEnerStart = (event) => {
     const value = event.target.value;
-    let stateEnerstart = parseFloat(IBD_THRESHOLD.toFixed(1)) * isIBD;
+//    let stateEnerstart = parseFloat(IBD_THRESHOLD.toFixed(1)) * isIBD;
     let ener_start = parseFloat(value);
     if (isNaN(ener_start)) {
       setEnerStart(value);
     } else {
-      if (ener_start < stateEnerstart) {
-        ener_start = stateEnerstart;
-      }
+//      if (ener_start < stateEnerstart) {
+//        ener_start = stateEnerstart;
+//      }
       if (eMax < ener_start) {
         ener_start = eMax;
       }
@@ -676,7 +676,7 @@ export const CalculatorPanel = ({ cores, spectrum }) => {
               <Form.Label>Half-Maximum Energy</Form.Label>
               <InputGroup>
                 <InputGroup.Prepend>
-                  <InputGroup.Text><i>E</i><sub>HM</sub></InputGroup.Text>
+                  <InputGroup.Text><i>T</i><sub>HM</sub></InputGroup.Text>
                 </InputGroup.Prepend>
                   <Form.Control
                   onChange={UIsetEnerStart}
@@ -751,19 +751,18 @@ export const CalculatorPanel = ({ cores, spectrum }) => {
             </p>
             <p>
             <b> Detection Efficiency Function</b><br />
-            Detection efficiency expressed as a function of antineutrino energy <i>E</i> is
-            valid for IBD only. Here it is approximated by
-            <Node>{String.raw`\varepsilon (E) = \frac {\varepsilon_\mathrm{max}} {1 + \exp(-\rho * (E - E_\mathrm{HM}))},`}</Node>{" "}
+            Detection efficiency is expressed as a function of kinetic energy <i>T</i> of the scattered lepton.
+            Here it is approximated by
+            <Node>{String.raw`\varepsilon (T) = \frac {\varepsilon_\mathrm{max}} {1 + \exp(-\rho * (T - T_\mathrm{HM}))},`}</Node>{" "}
             where <Node inline>{String.raw`\varepsilon_\mathrm{max}`}</Node> sets
             the maximum detection efficiency,{" "}
-            <Node inline>{String.raw`E_\mathrm{HM}`}</Node> is
-            the energy at half the maximum efficiency, and{" "}
+            <Node inline>{String.raw`T_\mathrm{HM}`}</Node> is
+            the kinetic energy at half the maximum efficiency, and{" "}
             <Node inline>{String.raw`\rho`}</Node> controls
             the rate the efficiency ramps up. 
             For monolithic detectors of Cherenkov and/or scintillation light the values of these parameters depend on the
             photosensitive surface and the target liquid. (Try {" "}
-            <Node inline>{String.raw`\rho = 3.5, E_\mathrm{HM} = 3.8`}</Node> MeV to 
-            approximate the curve on the slide from Marc.)
+            <Node inline>{String.raw`\rho = 3.5, T_\mathrm{HM} = 2.0`}</Node> MeV.)
             </p>
           </div>
         </Provider>

--- a/src/ui/output-calculator.jsx
+++ b/src/ui/output-calculator.jsx
@@ -6,7 +6,7 @@ import { PhysicsContext } from "../state";
 import { XSNames } from "../physics/neutrino-cross-section";
 import { IBD_THRESHOLD } from "../physics/derived";
 import { Num, Visible } from ".";
-import bins from "../physics/bins";
+import bins, {shiftByIBD} from "../physics/bins";
 import Plot from "react-plotly.js"
 
 const getCoreSums = (cores, min_i, max_i, low_i) => {
@@ -33,9 +33,10 @@ const detectorEfficiency = (
   if (perfect) {
     return spectrum;
   }
+  const shifted = shiftByIBD(spectrum)
   return bins.map(
     (eV, i) =>
-    effFunc(eV, Emax, rampUp, turnOn) * spectrum[i]
+    effFunc(eV, Emax, rampUp, turnOn) * shifted[i]
   );
 };
 

--- a/src/ui/output-calculator.jsx
+++ b/src/ui/output-calculator.jsx
@@ -215,6 +215,9 @@ export const CalculatorPanel = ({ cores, spectrum }) => {
 //      if (ener_start < stateEnerstart) {
 //        ener_start = stateEnerstart;
 //      }
+      if (ener_start < 0) {
+        ener_start = 0;
+      }
       if (eMax < ener_start) {
         ener_start = eMax;
       }
@@ -337,7 +340,8 @@ export const CalculatorPanel = ({ cores, spectrum }) => {
 
   // for now assume a flat spectrum with maximum energy of 10 MeV
   const bkgNuisanceNIU =
-    (bkgnuisance * (eMax - eMin)) / (10 - IBD_THRESHOLD * isIBD);
+    (bkgnuisance * (eMax - eMin) * 0.1);
+//    (bkgnuisance * (eMax - eMin)) / (10 - IBD_THRESHOLD * isIBD);
 
   let UIsignal = 0;
   let UIbackground = 0;

--- a/src/ui/output-calculator.jsx
+++ b/src/ui/output-calculator.jsx
@@ -486,7 +486,6 @@ export const CalculatorPanel = ({ cores, spectrum }) => {
         <Provider>
           <div>
             <small>Detected events = efficiency function x kinetic energy rate spectrum</small>
-//            <small>Detected events = efficiency fn (below) x interaction spectrum- {crossSection.crossSection}</small>
             <Table>
               <tbody>
               <tr>

--- a/src/ui/output-calculator.jsx
+++ b/src/ui/output-calculator.jsx
@@ -669,8 +669,7 @@ export const CalculatorPanel = ({ cores, spectrum }) => {
                   onChange={UIsetEffMax}
                   type="number"
                   step="0.1"
-                  value={isIBD? effMax: ""}
-                  disabled={!isIBD}
+                  value={effMax}
                 />
               </InputGroup>
             </Form.Group>
@@ -686,8 +685,7 @@ export const CalculatorPanel = ({ cores, spectrum }) => {
                   onChange={UIsetEnerStart}
                   type="number"
                   step="0.1"
-                  value={isIBD? enerStart : ""}
-                  disabled={!isIBD}
+                  value={enerStart}
                 />
                 <InputGroup.Append>
                   <InputGroup.Text>MeV</InputGroup.Text>
@@ -706,8 +704,7 @@ export const CalculatorPanel = ({ cores, spectrum }) => {
                   onChange={UIsetRampUp}
                   type="number"
                   step="0.1"
-                  value={isIBD? rampUp : ""}
-                  disabled={!isIBD}
+                  value={rampUp}
                 />
                 <InputGroup.Append>
                   <InputGroup.Text>

--- a/src/ui/output-calculator.jsx
+++ b/src/ui/output-calculator.jsx
@@ -6,15 +6,15 @@ import { PhysicsContext } from "../state";
 import { XSNames } from "../physics/neutrino-cross-section";
 import { IBD_THRESHOLD } from "../physics/derived";
 import { Num, Visible } from ".";
-import bins, {shiftByIBD} from "../physics/bins";
+import bins, {shiftByIBD, binWidth} from "../physics/bins";
 import Plot from "react-plotly.js"
 
 const getCoreSums = (cores, min_i, max_i, low_i) => {
   const lowSum = sum(
-    cores.map((core) => sum(core.detectorSignal.slice(min_i, Math.min(low_i, max_i))) * 0.01)
+    cores.map((core) => sum(core.detectorSignal.slice(min_i, Math.min(low_i, max_i))) * binWidth)
   );
   const highSum = sum(
-    cores.map((core) => sum(core.detectorSignal.slice(Math.max(low_i, min_i), max_i)) * 0.01)
+    cores.map((core) => sum(core.detectorSignal.slice(Math.max(low_i, min_i), max_i)) * binWidth)
   );
   return [lowSum + highSum, lowSum, highSum];
 };
@@ -264,9 +264,9 @@ export const CalculatorPanel = ({ cores, spectrum }) => {
     }
   };
 
-  const min_i = parseInt(eMin * 100);
-  const max_i = parseInt(eMax * 100);
-  const low_i = parseInt(IBD_THRESHOLD * 100);
+  const min_i = parseInt(eMin * (1/binWidth));
+  const max_i = parseInt(eMax * (1/binWidth));
+  const low_i = parseInt(IBD_THRESHOLD * (1/binWidth));
 
   const coreList = Object.values(cores).map((core) => {
     return {
@@ -314,28 +314,28 @@ export const CalculatorPanel = ({ cores, spectrum }) => {
         min_i,
         max_i
       )
-    ) * 0.01;
+    ) * binWidth;
   const geoU235NIU =
     sum(
       detectorEfficiency(effMax, rampUp, enerStart, spectrum.geoU235, isIBD).slice(
         min_i,
         max_i
       )
-    ) * 0.01;
+    ) * binWidth;
   const geoTh232NIU =
     sum(
       detectorEfficiency(effMax, rampUp, enerStart, spectrum.geoTh232, isIBD).slice(
         min_i,
         max_i
       )
-    ) * 0.01;
+    ) * binWidth;
   const geoK40betaNIU =
     sum(
       detectorEfficiency(effMax, rampUp, enerStart, spectrum.geoK40_beta, isIBD).slice(
         min_i,
         max_i
       )
-    ) * 0.01;
+    ) * binWidth;
   const geoTotalNIU = geoU238NIU + geoTh232NIU + geoK40betaNIU + geoU235NIU;
 
   // for now assume a flat spectrum with maximum energy of 10 MeV

--- a/src/ui/output-download.jsx
+++ b/src/ui/output-download.jsx
@@ -3,6 +3,7 @@ import { zip, sum } from "lodash";
 import { XSNames, XSAbrev } from "../physics/neutrino-cross-section";
 import { SECONDS_PER_YEAR } from "../physics/constants";
 import { PhysicsContext } from "../state";
+import bins, {binCount} from "../physics/bins"
 
 import { Card, Button } from "react-bootstrap";
 
@@ -61,7 +62,7 @@ export const OutputDownload = ({ cores, spectrum, detector, boron8 }) => {
   // Close Things
   const closestName = closestActiveCore?.name || "none";
   const closestSpectrum =
-    closestActiveCore?.detectorSignal || new Float32Array(1000).fill(0);
+    closestActiveCore?.detectorSignal || new Float32Array(binCount).fill(0);
 
   // custom cores
   const customClosestName = closestCustomCore?.name || "";
@@ -97,7 +98,7 @@ export const OutputDownload = ({ cores, spectrum, detector, boron8 }) => {
         };
 
   const downloadData = {
-    "bin center (MeV)": spectrum.geoU238.map((n, i) => 0.005 + i * 0.01),
+    "bin center (MeV)": bins,
     total: total,
     "IAEA cores": totalIAEA,
     [`closest IAEA Core (${closestName})`]: closestSpectrum,
@@ -106,7 +107,7 @@ export const OutputDownload = ({ cores, spectrum, detector, boron8 }) => {
     ...customCoreData,
   };
   const downloadGeoData = {
-    "bin center (MeV)": spectrum.geoU238.map((n, i) => 0.005 + i * 0.01),
+    "bin center (MeV)": bins,
     geo238U: spectrum.geoU238,
     geo235U: spectrum.geoU235,
     geo232Th: spectrum.geoTh232,

--- a/src/ui/physics-plots.jsx
+++ b/src/ui/physics-plots.jsx
@@ -7,8 +7,9 @@ import { XSAbrev, XSNames } from '../physics/neutrino-cross-section';
 import { PhysicsContext } from "../state"
 
 import { differentialCrossSectionElasticScattering, NeutrinoType, TEMax, differentialCrossSectionElasticScatteringAngular } from '../physics/neutrino-cross-section'
+import bins from "../physics/bins"
 
-const bins = (new Float64Array(1000)).map((v, i) => 0.005 + i/100)
+// TODO: bin assumption also why is it one larger?
 const cosTbins = (new Float64Array(1001)).map((v, i) => i/1000)
 
 const cumulativeFunc = (bins, func, eV, neutrinoType) => {

--- a/src/ui/plot.jsx
+++ b/src/ui/plot.jsx
@@ -5,9 +5,8 @@ import { sum } from "lodash";
 
 import {PhysicsContext} from '../state'
 
-//TODO this entire file has a lot of bin assumptions
+import bins, {binCount} from "../physics/bins"
 
-const evBins = new Float64Array(1000).map((v, i) => i * 0.01 + 0.005);
 
 export function NuSpectrumPlot({ cores, spectrum, detector, reactorLF}) {
   const { crossSection } = useContext(PhysicsContext)
@@ -20,28 +19,28 @@ export function NuSpectrumPlot({ cores, spectrum, detector, reactorLF}) {
     return previous.map(
       (value, index) => value + current.detectorSignal[index]
     );
-  }, new Float64Array(1000).fill(0));
+  }, new Float64Array(binCount).fill(0));
 
   const closestActiveIAEACoreSignal =
-    closestActiveIAEACore?.detectorSignal || new Float32Array(1000).fill(0);
+    closestActiveIAEACore?.detectorSignal || new Float32Array(binCount).fill(0);
 
   const customCores = coreList.filter((core) => core.custom === true);
   const customCoreSignal = customCores.reduce((previous, current) => {
     return previous.map(
       (value, index) => value + current.detectorSignal[index]
     );
-  }, new Float64Array(1000).fill(0));
+  }, new Float64Array(binCount).fill(0));
   
   const selectedCores = coreList.filter((core) => core.outputSignal === true);
   const selectedCoreSignal = selectedCores.reduce((previous, current) => {
     return previous.map(
       (value, index) => value + current.detectorSignal[index]
     );
-  }, new Float64Array(1000).fill(0));
+  }, new Float64Array(binCount).fill(0));
 
   const data = [
   {
-      x: evBins,
+      x: bins,
       y: totalCoreSignal,
       name: "Reactor cores",
       type: "scatter",
@@ -52,7 +51,7 @@ export function NuSpectrumPlot({ cores, spectrum, detector, reactorLF}) {
       visible: sum(totalCoreSignal) > 0,
     },
     {
-      x: evBins,
+      x: bins,
       y: closestActiveIAEACoreSignal,
       name: `Closest IAEA core<br />(${closestActiveIAEACore?.name || ""})`,
       type: "scatter",
@@ -61,7 +60,7 @@ export function NuSpectrumPlot({ cores, spectrum, detector, reactorLF}) {
       visible: sum(closestActiveIAEACoreSignal) > 0,
     },  
     {
-      x: evBins,
+      x: bins,
       y: selectedCoreSignal,
       name: `Selected Signal<br />(${selectedCores.length} cores)`,
       type: "scatter",
@@ -70,7 +69,7 @@ export function NuSpectrumPlot({ cores, spectrum, detector, reactorLF}) {
       visible: sum(selectedCoreSignal) > 0,
     },  
     {
-      x: evBins,
+      x: bins,
       y: customCoreSignal,
       name: "Custom cores",
       type: "scatter",
@@ -80,7 +79,7 @@ export function NuSpectrumPlot({ cores, spectrum, detector, reactorLF}) {
       visible: sum(customCoreSignal) > 0,
     },
     {
-      x: evBins,
+      x: bins,
       y: spectrum.geoU238,
       name: "Geo <sup>238</sup>U",
       type: "scatter",
@@ -91,7 +90,7 @@ export function NuSpectrumPlot({ cores, spectrum, detector, reactorLF}) {
       visible: sum(spectrum.geoU238) > 0,
     },
     {
-      x: evBins,
+      x: bins,
       y: spectrum.geoU235,
       name: "Geo <sup>235</sup>U",
       type: "scatter",
@@ -102,7 +101,7 @@ export function NuSpectrumPlot({ cores, spectrum, detector, reactorLF}) {
       visible: sum(spectrum.geoU235) > 0,
     },
     {
-      x: evBins,
+      x: bins,
       y: spectrum.geoTh232,
       name: "Geo <sup>232</sup>Th",
       type: "scatter",
@@ -113,7 +112,7 @@ export function NuSpectrumPlot({ cores, spectrum, detector, reactorLF}) {
       visible: sum(spectrum.geoTh232) > 0,
     },
     {
-      x: evBins,
+      x: bins,
       y: spectrum.geoK40_beta,
       name: "Geo <sup>40</sup>K (β<sup>-</sup>)",
       type: "scatter",

--- a/src/ui/plot.jsx
+++ b/src/ui/plot.jsx
@@ -5,6 +5,8 @@ import { sum } from "lodash";
 
 import {PhysicsContext} from '../state'
 
+//TODO this entire file has a lot of bin assumptions
+
 const evBins = new Float64Array(1000).map((v, i) => i * 0.01 + 0.005);
 
 export function NuSpectrumPlot({ cores, spectrum, detector, reactorLF}) {

--- a/src/ui/reactors-plots.jsx
+++ b/src/ui/reactors-plots.jsx
@@ -5,9 +5,9 @@ import Plot from "react-plotly.js";
 
 import { Isotopes } from "../physics/constants";
 import { neutrinoEnergyFor } from "../physics/helpers";
+import bins from "../physics/bins";
 
 export const FissionIsotopeSpectraPlots = () => {
-  const bins = new Float64Array(1000).map((v, i) => 0.005 + i / 100);
   const data = [
     {
       y: bins.map(neutrinoEnergyFor(Isotopes.U238)),


### PR DESCRIPTION
This is a work in progress PR so things can be tracked.

One thing I did discover is that our NIU calculations all make assumptions that the bins are 10kev wide (there is a _lot_ of 0.01 being multiplied everywhere)

Another oddity is all the cos theta bins for the physics plots have 1001 "bins". The only thing I can think of as for why is that these plots needed to be on closed interval vs the default of a right open interval.