### PR TITLE
Add T_min information to plots which depend on it

### DIFF
--- a/src/ui/physics-plots.jsx
+++ b/src/ui/physics-plots.jsx
@@ -822,7 +822,7 @@ export const CrossSectionPlots = () => {
     },
   ]
   var layout = {
-    title: "Total Cross Sections- Antineutrinos",
+    title: `Total Cross Sections- Antineutrinos<br /><sub>${"(ES T<sub>min</sub>= " + crossSection.elasticScatteringTMin.toFixed(1) + " MeV)"}</sub>`,
     yaxis: {
       title: { text: `Total Cross Section (cm<sup>2</sup>)` },
       type: 'log',
@@ -850,7 +850,7 @@ export const CrossSectionPlots = () => {
   };
   var config = {
     toImageButtonOptions: {
-      filename: 'Total-Cross-Sections-antinus'
+      filename: `Total-Cross-Sections-antinus_Tmin${crossSection.elasticScatteringTMin.toFixed(1)}`
     }
   };
   return (
@@ -904,7 +904,7 @@ export const CrossSectionPlotsNormal = () => {
     },
   ]
   var layout = {
-    title: "Total Cross Sections- Neutrinos",
+    title: `Total Cross Sections- Neutrinos<br /><sub>${"(T<sub>min</sub>= " + crossSection.elasticScatteringTMin.toFixed(1) + " MeV)"}</sub>`,
     yaxis: {
       title: { text: `Total Cross Section (cm<sup>2</sup>)` },
       type: 'log',
@@ -932,7 +932,7 @@ export const CrossSectionPlotsNormal = () => {
   };
   var config = {
     toImageButtonOptions: {
-      filename: 'Total-Cross-Sections-nus'
+      filename: `Total-Cross-Sections-nus_Tmin${crossSection.elasticScatteringTMin.toFixed(1)}`
     }
   };
   return (

--- a/src/ui/plot.jsx
+++ b/src/ui/plot.jsx
@@ -153,7 +153,7 @@ export function NuSpectrumPlot({ cores, spectrum, detector, reactorLF, xaxisExtr
     },
     yaxis: {
       range: [0, ymax * 1.05],
-      title: { text: `Rate dR/dE (NIU/MeV)<br /><sub>${crossSection.crossSection}</sub>` },
+      title: { text: `Rate dR/dE (NIU/MeV)<br /><sub>${crossSection.crossSection} ${isIBD? "": "T<sub>min</sub>: " + crossSection.elasticScatteringTMin.toFixed(1)}</sub>` },
       ...yaxisExtra
     },
     annotations: [
@@ -171,15 +171,6 @@ export function NuSpectrumPlot({ cores, spectrum, detector, reactorLF, xaxisExtr
   const config = { toImageButtonOptions: { width: 900, height: 500, scale: 2, filename: 'Antineutrino-Spectrum' } }
 
   if (!isIBD){
-    layout.annotations.push({
-      showarrow: false,
-      text: `T<sub>min</sub>: ${crossSection.elasticScatteringTMin.toFixed(1)}`,
-      x: -0.1,
-      xref: "paper",
-      y: -0.15,
-      yref: "paper",
-    })
-
     config.toImageButtonOptions.filename = `Antineutrino-Spectrum_Tmin${crossSection.elasticScatteringTMin.toFixed(1)}`
   }
   return (

--- a/src/ui/plot.jsx
+++ b/src/ui/plot.jsx
@@ -153,7 +153,7 @@ export function NuSpectrumPlot({ cores, spectrum, detector, reactorLF, xaxisExtr
     },
     yaxis: {
       range: [0, ymax * 1.05],
-      title: { text: `Rate dR/dE (NIU/MeV)<br /><sub>${crossSection.crossSection} ${isIBD? "": "T<sub>min</sub>: " + crossSection.elasticScatteringTMin.toFixed(1)}</sub>` },
+      title: { text: `Rate dR/dE (NIU/MeV)<br /><sub>${crossSection.crossSection} ${isIBD? "": "(T<sub>min</sub>= " + crossSection.elasticScatteringTMin.toFixed(1)}</sub> " MeV)"` },
       ...yaxisExtra
     },
     annotations: [

--- a/src/ui/plot.jsx
+++ b/src/ui/plot.jsx
@@ -153,7 +153,7 @@ export function NuSpectrumPlot({ cores, spectrum, detector, reactorLF, xaxisExtr
     },
     yaxis: {
       range: [0, ymax * 1.05],
-      title: { text: `Rate dR/dE (NIU/MeV)<br /><sub>${crossSection.crossSection} ${isIBD? "": "(T<sub>min</sub>= " + crossSection.elasticScatteringTMin.toFixed(1) + " MeV)"}` },
+      title: { text: `Rate dR/dE (NIU/MeV)<br /><sub>${crossSection.crossSection} ${isIBD? "": "(T<sub>min</sub>= " + crossSection.elasticScatteringTMin.toFixed(1) + " MeV)"}</sub>` },
       ...yaxisExtra
     },
     annotations: [

--- a/src/ui/plot.jsx
+++ b/src/ui/plot.jsx
@@ -11,6 +11,10 @@ import {XSNames} from "../physics/neutrino-cross-section"
 
 export function NuSpectrumPlot({ cores, spectrum, detector, reactorLF, xaxisExtra={}, yaxisExtra={}, layoutExtra={}, func=(v) => v}) {
   const { crossSection } = useContext(PhysicsContext)
+  const isIBD = +[XSNames.IBDSV2003, XSNames.IBDVB1999].includes(
+    crossSection.crossSection
+  );
+
   const coreList = Object.values(cores);
   const closestActiveIAEACore = coreList
     .filter((core) => core.detectorAnySignal && !core.custom)
@@ -164,13 +168,27 @@ export function NuSpectrumPlot({ cores, spectrum, detector, reactorLF, xaxisExtr
     ],
     ...layoutExtra
   };
+  const config = { toImageButtonOptions: { width: 900, height: 500, scale: 2, filename: 'Antineutrino-Spectrum' } }
+
+  if (!isIBD){
+    layout.annotations.push({
+      showarrow: false,
+      text: `T<sub>min</sub>: ${crossSection.elasticScatteringTMin.toFixed(1)}`,
+      x: -0.1,
+      xref: "paper",
+      y: -0.15,
+      yref: "paper",
+    })
+
+    config.toImageButtonOptions.filename = `Antineutrino-Spectrum_Tmin${crossSection.elasticScatteringTMin.toFixed(1)}`
+  }
   return (
     <Plot
       data={data}
       layout={layout}
       useResizeHandler={true}
       style={{ width: "100%" }}
-      config={{ toImageButtonOptions: { width: 900, height: 500, scale: 2, filename: 'Antineutrino-Spectrum' } }}
+      config={config}
     />
   );
 }

--- a/src/ui/plot.jsx
+++ b/src/ui/plot.jsx
@@ -153,7 +153,7 @@ export function NuSpectrumPlot({ cores, spectrum, detector, reactorLF, xaxisExtr
     },
     yaxis: {
       range: [0, ymax * 1.05],
-      title: { text: `Rate dR/dE (NIU/MeV)<br /><sub>${crossSection.crossSection} ${isIBD? "": "(T<sub>min</sub>= " + crossSection.elasticScatteringTMin.toFixed(1)}</sub> " MeV)"` },
+      title: { text: `Rate dR/dE (NIU/MeV)<br /><sub>${crossSection.crossSection} ${isIBD? "": "(T<sub>min</sub>= " + crossSection.elasticScatteringTMin.toFixed(1) + " MeV)"}` },
       ...yaxisExtra
     },
     annotations: [

--- a/src/ui/solar-plots.jsx
+++ b/src/ui/solar-plots.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, {useContext} from "react";
 
 import { Card } from "react-bootstrap";
 import Plot from "react-plotly.js";
@@ -8,6 +8,7 @@ import { range } from "lodash";
 import { SECONDS_PER_YEAR } from "../physics/constants";
 import { boron8Bins } from "../solar";
 import { detectorSunPosition } from "../detectors";
+import { PhysicsContext } from "../state";
 
 const plotDef = (cores, color) => {
   return {
@@ -188,6 +189,7 @@ export const AnalemmaPlot = ({ detector, cores, reactorLF }) => {
 };
 
 export const Boron8KEPlot = ({ boron8 }) => {
+  const {crossSection} = useContext(PhysicsContext)
   const data = [
     {
       y: boron8.boron8Ke,
@@ -200,7 +202,7 @@ export const Boron8KEPlot = ({ boron8 }) => {
     },
   ];
   var layout = {
-    title: "Kinetic Energy Spectrum",
+    title: `Kinetic Energy Spectrum<br /><sub>${"(T<sub>min</sub>= " + crossSection.elasticScatteringTMin.toFixed(1) + " MeV)"}</sub>`,
     yaxis: {
       title: { text: `dR/dT (NIU/MeV)` },
       autorange: true,
@@ -227,7 +229,7 @@ export const Boron8KEPlot = ({ boron8 }) => {
   };
   var config = {
     toImageButtonOptions: {
-      filename: "Solar-8B-ES-KE-Spectrum",
+      filename: `Solar-8B-ES-KE-Spectrum_Tmin${crossSection.elasticScatteringTMin.toFixed(1)}`,
     },
   };
   return (
@@ -249,6 +251,7 @@ export const Boron8KEPlot = ({ boron8 }) => {
 };
 
 export const Boron8SpectraPlot = ({ boron8 }) => {
+  const {crossSection} = useContext(PhysicsContext)
   const data = [
     {
       y: boron8.boron8Rate.map((x) => x * 1e1 * SECONDS_PER_YEAR * 1e32),
@@ -261,7 +264,7 @@ export const Boron8SpectraPlot = ({ boron8 }) => {
     },
   ];
   var layout = {
-    title: "<sup>8</sup>B Decay ES Rate Spectrum",
+    title: `<sup>8</sup>B Decay ES Rate Spectrum<br /><sub>${"(T<sub>min</sub>= " + crossSection.elasticScatteringTMin.toFixed(1) + " MeV)"}</sub>`,
     yaxis: {
       title: { text: `dR/dE (NIU/MeV)` },
       autorange: true,
@@ -288,7 +291,7 @@ export const Boron8SpectraPlot = ({ boron8 }) => {
   };
   var config = {
     toImageButtonOptions: {
-      filename: "Solar-8B-ES-Rate-Spectrum",
+      filename: `Solar-8B-ES-Rate-Spectrum_Tmin${crossSection.elasticScatteringTMin.toFixed(1)}`,
     },
   };
   return (


### PR DESCRIPTION
So far I've only added it to the main spectrum plot for refinement of T_min annotation location and filename pattern. Once we are happy with how it behaves, I'll add it to all the other plots which have a T_min dependency.