### PR TITLE
Make operating detector layer

### DIFF
--- a/src/ui/map.jsx
+++ b/src/ui/map.jsx
@@ -248,7 +248,7 @@ export function NuMap({
             <CoreCircles cores={cores} zoom={zoom} shutdownCores={false}/>
           </LayerGroup>
         </LayersControl.Overlay>
-        <LayersControl.Overlay checked name="Detector Locations">
+        <LayersControl.Overlay checked name="Detector Sites">
           <LayerGroup>
             <DetectorCircles
               detectors={detectorList}


### PR DESCRIPTION
Better viewing if there are separate layers for operational and non-operational detection sites. In the code this functionally similar to active and shutdown reactor cores.